### PR TITLE
Fix cluster tracing issue with cache expiration

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/trace-lib.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/data-hub/4/impl/trace-lib.xqy
@@ -71,7 +71,7 @@ declare function trace:enable-tracing($enabled as xs:boolean)
 declare function trace:enabled() as xs:boolean
 {
   let $key := "tracing-enabled"
-  let $flag :=  hul:from-field-cache-or-empty($key, ())
+  let $flag :=  hul:from-field-cache-or-empty($key, xs:dayTimeDuration("PT0.3S"))
   return
     if (exists($flag)) then
       $flag
@@ -88,7 +88,7 @@ declare function trace:enabled() as xs:boolean
             )
           )
         ',(), map:new(map:entry("database", xdmp:modules-database()))),
-        xs:dayTimeDuration("PT1M")
+        xs:dayTimeDuration("PT0.3S")
       )
 };
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -353,44 +353,13 @@ public class HubTestBase {
     	}
     }
 
+    // TODO, inject tracing
     protected void enableTracing() {
-    	if(!isLBRun()) {
-	        ManageClient manageClient = ((HubConfigImpl)getHubFlowRunnerConfig()).getManageClient();
-	        String resp = manageClient.getJson("/manage/v2/hosts?format=json");
-	        JsonNode actualObj = null;
-			try {
-				actualObj = new ObjectMapper().readTree(resp);
-			} catch (IOException e1) {
-				// TODO Auto-generated catch block
-				e1.printStackTrace();
-			}
-			JsonNode nameNode = actualObj.path("host-default-list").path("list-items");
-			List<String> hosts = nameNode.findValuesAsText("nameref");
-	        hosts.forEach(serverHost ->
-			{
-				try {
-					DatabaseClient client = getClient(serverHost, stagingPort, HubConfig.DEFAULT_STAGING_NAME, flowRunnerUser, flowRunnerPassword, stagingAuthMethod);
-					Tracing.create(client).enable();
-					clients.add(client);
-				} catch (Exception e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				}
-			});
-    	}
+        Tracing.create(stagingClient).enable();
     }
 
     protected void disableTracing() {
-    	if(!isLBRun()) {
-	        clients.forEach(client ->
-			{
-				Tracing.create(client).disable();
-				client.newServerEval().xquery("xquery version \"1.0-ml\";\n" +
-						"import module namespace hul = \"http://marklogic.com/data-hub/hub-utils-lib\" at \"/data-hub/4/impl/hub-utils-lib.xqy\";\n" +
-						"hul:invalidate-field-cache(\"tracing-enabled\")").eval();
-	
-			});
-    	}
+        Tracing.create(stagingClient).disable();
     }
 
     //getHubAdminConfig is used for installation, scaffolding


### PR DESCRIPTION
Hi @srinathgit this PR has fixes to the enode code such that the tracing tests pass on a cluster, and I also modified HubTestBase to just use tracing methods as intended.

So this should be a fix to marklogic/datahub-central#1027/ DHFPROD-653.
